### PR TITLE
Tooling overhaul

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+POSTGRES_USER=<username>
+POSTGRES_PASSWORD=<password>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Console:
 * `./climb-ctl jc`
 * you can access the Postgres directly with:
 * `./climb-ctl db-connect`
-* `psql -U postgres` (or you can change the default username/password)
 
 Current and Future Explorations:
 * Graphing data in more interactive ways. Build a front-end interface with Highcharts

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Usage:
 
 Console:
 * You can open a console in the Jupyter kernel to access all variables in your notebooks:
-* `./climb-ctl run bash`
-* from within the container: `jupyter console --existing` (or `jc` which is aliased.)
+* `./climb-ctl jc`
 * you can access the Postgres directly with:
 * `./climb-ctl db-connect`
 * `psql -U postgres` (or you can change the default username/password)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 An experimental climbing prediction engine, based on Mountain Project Tick data. Currently expanding Map & Geospatial capabilities.
 
 Requirements:
-* Docker (python, jupyter...etc all run in a docker container.)
+* Docker (Python, Jupyter...etc all run in a Docker container.)
+* Docker Compose
 * Postgres (runs in Docker)
 
 Setup:
 * clone the repo.
-* `docker-compose build`
-* `docker-compose run`
+* create a `.env` file in the root of the repo, based on `./.env.example`
+* `./climb-ctl start`
 * This will start 2 containers
 * Jupyter server running on localhost:8887
 * Postgres container running on port 5433 locally (5432 within the docker container)
@@ -21,16 +22,16 @@ Usage:
 * `3_hyper_param_tuning.ipynb` does cross validation and hyper parameter tuning.
 
 Console:
-* You can open a console in the jupyter kernal to access all variables in your notebooks:
-* `docker exec -it climb_wise-app-1 /bin/bash`
+* You can open a console in the Jupyter kernel to access all variables in your notebooks:
+* `./climb-ctl run bash`
 * from within the container: `jupyter console --existing` (or `jc` which is aliased.)
-* you can access the postgres db directly with:
-* `docker exec -it climb_wise-db-1`
+* you can access the Postgres directly with:
+* `./climb-ctl db-connect`
 * `psql -U postgres` (or you can change the default username/password)
 
 Current and Future Explorations:
 * Graphing data in more interactive ways. Build a front-end interface with Highcharts
-* Traveling Salseman Problem w additional constraints like weather, seasonality for planning climbing/outdoor trips.)
+* Traveling Salesman Problem w additional constraints like weather, seasonality for planning climbing/outdoor trips.)
 * Recommendation engine based on ticks, star ratings, frequented areas...etc.
 * Use map layers to get additional data about climbing routes/areas, such as rock type based on geology layers, and feed that into recommentation and/or prediction engines.
 

--- a/climb-ctl
+++ b/climb-ctl
@@ -11,6 +11,8 @@ main() {
 __execute_arg() {
   if [[ ! ${COMMAND} || "${COMMAND}" == "-h" || "${COMMAND}" == "--help" ]]; then
     __display_help
+  elif [[ ${COMMAND} == "db-connect" ]]; then
+    __db_connect
   elif [[ ${COMMAND} == "logs" ]]; then
     __watch_logs
   elif [[ ${COMMAND} == "prune" ]]; then
@@ -36,6 +38,7 @@ __execute_arg() {
 __display_help() {
   echo ""
   echo "------------------- available arguments -------------------"
+  echo "db-connect - connect to the postgres db"
   echo "logs - watch database and app logs"
   echo "prune - remove containers"
   echo "rebuild - rebuild images"
@@ -46,6 +49,11 @@ __display_help() {
   echo "yolo - completely destroy and recreate all containers, images, and volumes"
 }
 
+__db_connect() {
+  echo ""
+  echo "== Connecting to DB =="
+  docker compose exec -it db bash
+}
 __start_dev() {
   echo ""
   echo "== Starting containers =="

--- a/climb-ctl
+++ b/climb-ctl
@@ -77,7 +77,7 @@ __remove_containers() {
   echo "== Deleting all containers =="
   existing_containers=$(docker ps -a | grep -i climb_wise) || true
   if [[ ! -z "$existing_containers" ]]; then
-    container_ids=$(echo $existing_containers | awk '{print $1}')
+    container_ids=$(echo $existing_containers | awk '{print $1}' | tr '\n' ' ')
     docker rm -f "${container_ids}"
   else
     echo "No containers to remove"
@@ -89,8 +89,7 @@ __remove_images() {
   echo "== Removing images =="
   existing_images=$(docker image ls -a | grep -i climb_wise) || true
   if [[ ! -z "$existing_images" ]]; then
-    image_ids=$(echo $existing_images | awk '{print $3}')
-    docker rmi "${image_ids}"
+    echo $existing_images | awk '{print $3}' | tr '\n' ' ' | xargs docker rmi
   else
     echo "No images to remove"
   fi
@@ -98,10 +97,10 @@ __remove_images() {
 
 __remove_volumes() {
   echo ""
-  echo "== Removing images =="
+  echo "== Removing volumes =="
   existing_volumes=$(docker volume ls | grep -i climb_wise) || true
   if [[ ! -z "$existing_volumes" ]]; then
-    volume_names=$(echo $existing_volumes | awk '{print $2}')
+    volume_names=$(echo $existing_volumes | awk '{print $2}' | tr '\n' ' ')
     docker volume rm -f "${volume_names}"
   else
     echo "No volumes to remove"

--- a/climb-ctl
+++ b/climb-ctl
@@ -5,10 +5,10 @@ COMMAND=$1
 ARGS="${@:2}"
 
 main() {
-  __execute_arg $COMMAND
+  __execute_cmd $COMMAND
 }
 
-__execute_arg() {
+__execute_cmd() {
   if [[ ! ${COMMAND} || "${COMMAND}" == "-h" || "${COMMAND}" == "--help" ]]; then
     __display_help
   elif [[ ${COMMAND} == "db-connect" ]]; then

--- a/climb-ctl
+++ b/climb-ctl
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -e
+COMMAND=$1
+ARGS="${@:2}"
+
+main() {
+  __execute_arg $COMMAND
+}
+
+__execute_arg() {
+  if [[ ! ${COMMAND} || "${COMMAND}" == "-h" || "${COMMAND}" == "--help" ]]; then
+    __display_help
+  elif [[ ${COMMAND} == "logs" ]]; then
+    __watch_logs
+  elif [[ ${COMMAND} == "prune" ]]; then
+    __remove_containers
+  elif [[ ${COMMAND} == "rebuild" ]]; then
+    __rebuild_dev
+  elif [[ ${COMMAND} == "restart" ]]; then
+    __restart_dev
+  elif [[ ${COMMAND} == "run" ]]; then
+    __run_command $ARGS
+  elif [[ ${COMMAND} == "start" ]]; then
+    __start_dev
+  elif [[ ${COMMAND} == "stop" ]]; then
+    __stop_dev
+  elif [[ ${COMMAND} == "yolo" ]]; then
+    __yolo_environment
+  else
+    echo "./climb-ctl requires an argument. Example: './climb-ctl start'"
+    echo "No valid argument supplied."
+  fi
+}
+
+__display_help() {
+  echo ""
+  echo "------------------- available arguments -------------------"
+  echo "logs - watch database and app logs"
+  echo "prune - remove containers"
+  echo "rebuild - rebuild images"
+  echo "restart - stops and restarts development environment"
+  echo "run - run a command on the app container"
+  echo "start - starts all containers"
+  echo "stop - stop all containers"
+  echo "yolo - completely destroy and recreate all containers, images, and volumes"
+}
+
+__start_dev() {
+  echo ""
+  echo "== Starting containers =="
+  docker compose up -d
+}
+
+__stop_dev() {
+  echo ""
+  echo "== Stopping containers =="
+  docker compose down
+}
+
+__watch_logs(){
+  log_rm="docker compose logs -f"
+  echo "== Watching docker compose logs =="
+  eval $log_rm
+}
+
+__remove_containers() {
+  echo ""
+  echo "== Deleting all containers =="
+  existing_containers=$(docker ps -a | grep -i climb_wise) || true
+  if [[ ! -z "$existing_containers" ]]; then
+    container_ids=$(echo $existing_containers | awk '{print $1}')
+    docker rm -f "${container_ids}"
+  else
+    echo "No containers to remove"
+  fi
+}
+
+__remove_images() {
+  echo ""
+  echo "== Removing images =="
+  existing_images=$(docker image ls -a | grep -i climb_wise) || true
+  if [[ ! -z "$existing_images" ]]; then
+    image_ids=$(echo $existing_images | awk '{print $3}')
+    docker rmi "${image_ids}"
+  else
+    echo "No images to remove"
+  fi
+}
+
+__remove_volumes() {
+  echo ""
+  echo "== Removing images =="
+  existing_volumes=$(docker volume ls | grep -i climb_wise) || true
+  if [[ ! -z "$existing_volumes" ]]; then
+    volume_names=$(echo $existing_volumes | awk '{print $2}')
+    docker volume rm -f "${volume_names}"
+  else
+    echo "No volumes to remove"
+  fi
+}
+
+__yolo_environment() {
+  echo "Warning: This will destroy all of your existing containers, volumes, and images. Do you wish to continue? [y/n]"
+  read -r destroy_dev_prompt
+
+  if [ $(echo $destroy_dev_prompt | tr '[:upper:]' '[:lower:]') != "y" ]; then
+    return
+  else
+    echo ""
+    echo "== Resetting docker environment =="
+    __stop_dev
+    __remove_containers
+    __remove_images
+    __remove_volumes
+    __start_dev
+  fi
+}
+
+__restart_dev() {
+  __stop_dev
+  __start_dev
+}
+
+__run_command() {
+  echo ""
+  echo "== Running command $@ =="
+  docker compose run -it --rm app $@
+}
+
+__rebuild_dev() {
+  echo ""
+  echo "== Rebuilding containers =="
+  __stop_dev
+  docker-compose up -d --build
+}
+
+main

--- a/climb-ctl
+++ b/climb-ctl
@@ -13,6 +13,8 @@ __execute_arg() {
     __display_help
   elif [[ ${COMMAND} == "db-connect" ]]; then
     __db_connect
+  elif [[ ${COMMAND} == "jc" ]]; then
+    __jupyter_console
   elif [[ ${COMMAND} == "logs" ]]; then
     __watch_logs
   elif [[ ${COMMAND} == "prune" ]]; then
@@ -39,6 +41,7 @@ __display_help() {
   echo ""
   echo "------------------- available arguments -------------------"
   echo "db-connect - connect to the postgres db"
+  echo "jc - open jupyter console on running app"
   echo "logs - watch database and app logs"
   echo "prune - remove containers"
   echo "rebuild - rebuild images"
@@ -54,6 +57,7 @@ __db_connect() {
   echo "== Connecting to DB =="
   docker compose exec -it db bash
 }
+
 __start_dev() {
   echo ""
   echo "== Starting containers =="
@@ -140,6 +144,10 @@ __rebuild_dev() {
   echo "== Rebuilding containers =="
   __stop_dev
   docker-compose up -d --build
+}
+
+__jupyter_console() {
+  docker compose exec -it app jupyter console --existing
 }
 
 main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   db:
     build:
       context: .
-      dockerfile: Dockerfile.postgres
+      dockerfile: ./docker/Dockerfile.db
     volumes:
       - pgdata:/var/lib/postgresql/data  # Persistent storage for database
     ports:
@@ -11,8 +11,9 @@ services:
       - .env
 
   app:
-    build: .
-    command: bash -c "./jupyter/start_jupyter.sh && tail -f /app/log/jupyter.log"
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.app
     volumes:
       - .:/app
     ports:

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -24,14 +24,12 @@ RUN mkdir -p /app/log
 RUN touch /app/log/jupyter.log
 RUN chmod 777 /app/log/jupyter.log
 
-# Copy some files into the container
-COPY jupyter/start_jupyter.sh jupyter/
-RUN chmod +x jupyter/start_jupyter.sh
-
 # Copy your project files into the container
 COPY . .
+RUN chmod +x jupyter/start_jupyter.sh
+RUN chmod +x docker/entrypoint.sh
 
 RUN echo "alias jc='jupyter console --existing'" >> ~/.bashrc && \
     echo "source ~/.bashrc" >> ~/.bash_profile
 
-CMD ["/app/jupyter/start_jupyter.sh && tail -f /app/log/jupyter.log"]
+CMD ["/app/docker/entrypoint.sh"]

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -5,12 +5,17 @@ FROM python:3.13-slim
 # Set the working directory inside the container
 WORKDIR /app
 
-# Install common utilities
-RUN apt-get update && apt-get install -y procps less vim curl wget net-tools iputils-ping graphviz build-essential cmake
+# Install system packages
+RUN apt-get update && \
+    apt-get install -y \
+      procps less vim curl wget \
+      net-tools iputils-ping graphviz \
+      build-essential cmake
 
 # Install Python packages
-COPY docker/requirements.txt docker/
-RUN pip install --no-cache-dir -r docker/requirements.txt
+COPY docker/requirements.txt /app
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
 # needed because elkai doesn't have a prebiuld wheel for this docker image (Debian)
 RUN pip install elkai --no-binary elkai
 
@@ -29,5 +34,4 @@ COPY . .
 RUN echo "alias jc='jupyter console --existing'" >> ~/.bashrc && \
     echo "source ~/.bashrc" >> ~/.bash_profile
 
-# Set the default command to run when the container starts
-CMD ["/bin/bash"]
+CMD ["/app/jupyter/start_jupyter.sh && tail -f /app/log/jupyter.log"]

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -9,6 +9,3 @@ RUN apt-get update && \
 # Copy the initialization script to the Docker container
 COPY docker/init_postgis.sh /docker-entrypoint-initdb.d/
 RUN chmod +x /docker-entrypoint-initdb.d/init_postgis.sh
-
-
-

--- a/docker/commit_curent_container_to_image.sh
+++ b/docker/commit_curent_container_to_image.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-docker commit climb_wise-app-1 climb_wise-app-commited
-echo "Container climb_wise-app-1 has been committed to image climb_wise-app-committed"

--- a/docker/console_docker.sh
+++ b/docker/console_docker.sh
@@ -1,1 +1,0 @@
-docker exec -it climb_wise /bin/bash

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+touch /app/log/jupyter.log
+
+# Start Jupyter in the background
+/app/jupyter/start_jupyter.sh &
+
+exec tail -f /app/log/jupyter.log

--- a/models.py
+++ b/models.py
@@ -128,11 +128,11 @@ class Waypoint(Base):
 ### FUNCTIONS ###
 
 def get_engine():
-    db_user = os.getenv('DB_USER')
-    db_password = os.getenv('DB_PASSWORD')
-    db_host = os.getenv('DB_HOST', 'climb_wise-db-1')
-    db_port = os.getenv('DB_PORT', 5432)
-    db_name = os.getenv('DB_NAME', 'climb_wise_local')
+    db_user = os.getenv('POSTGRES_USER')
+    db_password = os.getenv('POSTGRES_PASSWORD')
+    db_host = os.getenv('POSTGRES_HOST', 'climb_wise-db-1')
+    db_port = os.getenv('POSTGRES_PORT', 5432)
+    db_name = os.getenv('POSTGRES_NAME', 'climb_wise_local')
     db_url = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
     return create_engine(db_url)
 


### PR DESCRIPTION
## Overview

This PR does a handful of things to improve the development environment.

- add a script `./climb-ctl` for managing docker and containers. Learn how to use the tool with `./climb-ctl -h`
- add an entrypoint script for the docker container
- update documentation
- restructure Dockerfiles and minor improvements
- add functionality for rebuilding images and remove docker commit script
- ensure no blowups when logfile doesn't exist by adding log directory, `.keep`, and entrypoint logic
- rename environment variables to postgres defaults, to facilitate working postgres setup on first install